### PR TITLE
Add lightweight Postgresql instructions

### DIFF
--- a/k8s/.gitignore
+++ b/k8s/.gitignore
@@ -1,0 +1,6 @@
+/.terraform
+/kubeconfig
+/override.tf
+/ssh_priv_key
+terraform.tfstate
+

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -64,3 +64,45 @@ Get_Access = ssh -i ssh_priv_key root@147.75.195.75
 
 You can now login to the first node in the cluster by copy and pasting the ssh command from the output.
 
+Optionally, you can also get access to `kubectl` from your local machine, which is more convenient than logging into the master each time.
+
+Install k3sup
+
+```sh
+curl -SLsf https://get.k3sup.dev | sudo sh
+```
+
+Now fetch the KUBECONFIG to the local directory:
+
+```sh
+k3sup install --ip 147.75.67.211 --user root \
+  --skip-install \
+  --context packet-iot \
+  --ssh-key ./ssh_priv_key
+```
+
+`k3sup` will download an correctly configured KUBECONFIG file to your local directory. 
+
+```sh
+export KUBECONFIG=`pwd`/kubeconfig
+kubectl get node -o wide
+```
+
+You can also merge the config to your local `~/.kube/config` file with:
+
+```sh
+k3sup install --ip 147.75.67.211 --user root \
+  --skip-install \
+  --ssh-key ./ssh_priv_key \
+  --merge \
+  --context packet-iot \
+  --local-path $HOME/.kube/config
+```
+
+See the new context via:
+
+```sh
+kubectl config get-contexts
+
+kubectl config set-contexts NAME
+```

--- a/postgresql/README.md
+++ b/postgresql/README.md
@@ -1,3 +1,52 @@
+## Postgresql installation
+
+You can pick one of the two options for installing Postgresql.
+
+## Light-weight option (k3sup) - standard Postgresql
+
+This option is the simplest and will get Postgresql running in the shortest amount of time.
+
+Get `k3sup`, if you don't already have it:
+
+```sh
+curl -SLfs https://get.k3sup.dev | sudo sh
+```
+
+Install `postgresql` and copy down the instructions printed at the end with how to connect, and how to get your password.
+
+```sh
+k3sup app install postgresql
+```
+
+You'll see output like the following, feel free to test it out.
+
+```sh
+=======================================================================
+= postgresql has been installed.                                      =
+=======================================================================
+
+PostgreSQL can be accessed via port 5432 on the following DNS name from within your cluster:
+
+        postgresql.default.svc.cluster.local - Read/Write connection
+
+To get the password for "postgres" run:
+
+    export POSTGRES_PASSWORD=$(kubectl get secret --namespace default postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+
+To connect to your database run the following command:
+
+    kubectl run postgresql-client --rm --tty -i --restart='Never' --namespace default --image docker.io/bitnami/postgresql:11.6.0-debian-9-r0 --env="PGPASSWORD=$POSTGRES_PASSWORD" --command -- psql --host postgresql -U postgres -d postgres -p 5432
+
+To connect to your database from outside the cluster execute the following commands:
+
+    kubectl port-forward --namespace default svc/postgresql 5432:5432 &
+        PGPASSWORD="$POSTGRES_PASSWORD" psql --host 127.0.0.1 -U postgres -d postgres -p 5432
+
+# Find out more at: https://github.com/helm/charts/tree/master/stable/postgresql
+```
+
+## Postgresql with KubeDB for highly-availability and statefulness
+
 Install Helm:
 
 https://helm.sh/docs/intro/install/


### PR DESCRIPTION
* Adds lightweight, automated, easy way to add Postgresql
* Retains KubeDB for highly available, more complex option for
those who would benefit from the persistent storage options.