### PR TITLE
Update emitter to use k3s provisioner (fixes: #18) 

### DIFF
--- a/emitter/README.md
+++ b/emitter/README.md
@@ -16,23 +16,36 @@ docker logs emitter
 
 Copy the new license into `broker.yaml` and start the broker and service.
 
+For simplicity, the broker is deployed to the `openfaas` namespace.
+
 ```
-kubectl create namespace iot
-kubectl create -f broker.yaml
-kubectl create -f service.yaml
+kubectl apply -f broker.yaml
+kubectl apply -f service.yaml
 ```
 
 List the services to obtain the IP address of the Emitter load balancer.
 
 ```
- % kubectl --namespace iot get service emitter
+ % kubectl --namespace openfaas get service emitter
  NAME      TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S) AGE
- emitter   LoadBalancer   10.111.110.157   172.217.14.164  80:30790/TCP,443:30705/TCP   8m40s
+ emitter   ClusterIP   10.111.110.157    <pending>  8080:30790/TCP,8443:30705/TCP   8m40s
+```
+
+Check the logs of the service:
+
+```
+kubectl logs statefulset.apps/broker -n openfaas
+```
+
+Port-forward the Emitter's UI so that you can generate a channel key.
+
+```sh
+kubectl port-forward -n openfaas svc emitter 8080:8080 &
 ```
 
 You can now use the IP address to access the Emitter UI. In the above example
-you would go to `http://172.217.14.164/keygen`. From there you can create
+you would go to `http://127.0.0.1:8080/keygen`. From there you can create
 channel keys, which allow you to secure individual channels and start using
 Emitter.
 
-You can now proceed  with the [Emitter documentation](https://github.com/emitter-io/emitter).
+You can now proceed with the [Emitter documentation](https://github.com/emitter-io/emitter).

--- a/emitter/broker.yaml
+++ b/emitter/broker.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: broker
-  namespace: iot
+  namespace: openfaas
 spec:
   selector:
     matchLabels:
@@ -14,7 +14,7 @@ spec:
       labels:
         app: broker
         role: broker
-        namespace: iot
+        namespace: openfaas
     spec:
       terminationGracePeriodSeconds: 30
       affinity:
@@ -54,7 +54,7 @@ spec:
       name: broker-volume
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: csi-packet-standard
+      storageClassName: local-path
       resources:
         requests:
-          storage: 50Gi
+          storage: 10Gi

--- a/emitter/service.yaml
+++ b/emitter/service.yaml
@@ -2,16 +2,16 @@ apiVersion: v1
 kind: Service
 metadata:
   name: emitter
-  namespace: iot
+  namespace: openfaas
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     app: broker
-    namespace: iot
+    namespace: openfaas
   ports:
-    - port: 80
+    - port: 8080
       targetPort: 8080
       name: http
-    - port: 443
-      targetPort: 443
+    - port: 8443
+      targetPort: 8443
       name: https

--- a/k8s/.gitignore
+++ b/k8s/.gitignore
@@ -1,0 +1,6 @@
+/.terraform
+/kubeconfig
+/override.tf
+/ssh_priv_key
+terraform.tfstate
+

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -64,3 +64,45 @@ Get_Access = ssh -i ssh_priv_key root@147.75.195.75
 
 You can now login to the first node in the cluster by copy and pasting the ssh command from the output.
 
+Optionally, you can also get access to `kubectl` from your local machine, which is more convenient than logging into the master each time.
+
+Install k3sup
+
+```sh
+curl -SLsf https://get.k3sup.dev | sudo sh
+```
+
+Now fetch the KUBECONFIG to the local directory:
+
+```sh
+k3sup install --ip 147.75.67.211 --user root \
+  --skip-install \
+  --context packet-iot \
+  --ssh-key ./ssh_priv_key
+```
+
+`k3sup` will download an correctly configured KUBECONFIG file to your local directory. 
+
+```sh
+export KUBECONFIG=`pwd`/kubeconfig
+kubectl get node -o wide
+```
+
+You can also merge the config to your local `~/.kube/config` file with:
+
+```sh
+k3sup install --ip 147.75.67.211 --user root \
+  --skip-install \
+  --ssh-key ./ssh_priv_key \
+  --merge \
+  --context packet-iot \
+  --local-path $HOME/.kube/config
+```
+
+See the new context via:
+
+```sh
+kubectl config get-contexts
+
+kubectl config set-contexts NAME
+```

--- a/postgresql/README.md
+++ b/postgresql/README.md
@@ -1,3 +1,52 @@
+## Postgresql installation
+
+You can pick one of the two options for installing Postgresql.
+
+## Light-weight option (k3sup) - standard Postgresql
+
+This option is the simplest and will get Postgresql running in the shortest amount of time.
+
+Get `k3sup`, if you don't already have it:
+
+```sh
+curl -SLfs https://get.k3sup.dev | sudo sh
+```
+
+Install `postgresql` and copy down the instructions printed at the end with how to connect, and how to get your password.
+
+```sh
+k3sup app install postgresql
+```
+
+You'll see output like the following, feel free to test it out.
+
+```sh
+=======================================================================
+= postgresql has been installed.                                      =
+=======================================================================
+
+PostgreSQL can be accessed via port 5432 on the following DNS name from within your cluster:
+
+        postgresql.default.svc.cluster.local - Read/Write connection
+
+To get the password for "postgres" run:
+
+    export POSTGRES_PASSWORD=$(kubectl get secret --namespace default postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+
+To connect to your database run the following command:
+
+    kubectl run postgresql-client --rm --tty -i --restart='Never' --namespace default --image docker.io/bitnami/postgresql:11.6.0-debian-9-r0 --env="PGPASSWORD=$POSTGRES_PASSWORD" --command -- psql --host postgresql -U postgres -d postgres -p 5432
+
+To connect to your database from outside the cluster execute the following commands:
+
+    kubectl port-forward --namespace default svc/postgresql 5432:5432 &
+        PGPASSWORD="$POSTGRES_PASSWORD" psql --host 127.0.0.1 -U postgres -d postgres -p 5432
+
+# Find out more at: https://github.com/helm/charts/tree/master/stable/postgresql
+```
+
+## Postgresql with KubeDB for highly-availability and statefulness
+
 Install Helm:
 
 https://helm.sh/docs/intro/install/


### PR DESCRIPTION
* Fixes: 18
* k3s ships with the local-path provisioner, so the PV had to be
changed for that
* The Packet configuration for k3s has no LoadBalancer, so this
is changed to port-forwarding as a fix
