### PR TITLE
Fix emitter instructions and add sample publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,86 @@ git clone https://github.com/openfaas-incubator/mqtt-connector
 cd mqtt-connector
 ```
 
-Edit `chart/mqtt-connector/values.yaml` and update the CHANNEL_KEY value from the step above.
+Edit `chart/mqtt-connector/values.yaml`
+
+* Set `trimChannelKey:` to `false`
+* Set `topic:` - replace `CHANNEL_KEY` with the value from the previous step, for example: `i-Xrxb7mpm-bs5LVY3jDU_kcE2XAgnyY/drone-position/`
+* Set `broker:` to `tcp://emitter:8080`
+
+For example:
 
 Apply the changes:
 
 ```sh
-cd mqtt-connector/chart/
+cd mqtt-connector
+cd chart
 
-helm template -n openfaas --namespace openfaas mqtt-connector/ --values mqtt
--connector/values.yaml | kubectl apply -f -
+export PATH=$PATH:~/.k3sup/bin/
+
+helm template -n openfaas --namespace openfaas mqtt-connector/ --values mqtt-connector/values.yaml | kubectl apply -f -
+```
+
+Check the logs:
+
+```sh
+kubectl logs -n openfaas deployment.apps/openfaas-mqtt-connector -f
+
+2019/12/13 17:05:43 Topic: i-Xrxb7mpm-bs5LVY3jDU_kcE2XAgnyY/drone-position/     Broker: tcp://emitter:8080
+```
+
+Feel free to try publishing a message:
+
+* Create `publisher.py`
+
+```
+import paho.mqtt.publish as publish
+import paho.mqtt.client as mqtt
+import os, json
+
+def on_publish(client,userdata,result):
+    print("data published \n")
+    pass
+
+client = mqtt.Client("127.0.0.1:8081", transport="websockets")
+
+client.on_publish = on_publish
+broker = "127.0.0.1"
+port = 8081
+
+client.connect(broker, port)
+
+payload = json.dumps({"name": "Carpark-watch", "tempCelsius": 3.5, "location": {"lat": 52.5740072, "lon": -0.2399354}, "batteryMv": 2700})
+
+ret = client.publish(os.getenv("CHANNEL_KEY"), payload)
+print(ret)
+```
+
+* Make sure the emitter is port-forwarded:
+
+```sh
+kubectl port-forward -n openfaas svc/emitter 8081:8080
+```
+
+* Run the publisher
+
+```sh
+# Install the MQTT broker library
+sudo pip3 install paho-mqtt  # Alternatively use `pip`
+
+export CHANNEL_KEY="i-Xrxb7mpm-bs5LVY3jDU_kcE2XAgnyY/drone-position/?ttl=1200" # as per values.yaml
+
+python3 ./publisher.py       # Alternatively use `python`
+```
+
+You should see this message:
+
+```sh
+2019/12/13 17:07:16 Invoking (http://gateway.openfaas:8080) on topic: "drone-position/", value: "{\"name\": \"Carpark-watch\", \"tempCelsius\": 3.5, \"location\": {\"lat\": 52.5740072, \"lon\": -0.2399354}, \"batteryMv\": 2700}"
+2019/12/13 17:07:16 Invoke function: db-inserter.openfaas-fn
+[200] drone-position/ => db-inserter.openfaas-fn
+{"status":"OK"}
+2019/12/13 17:07:16 connector-sdk got result: [200] drone-position/ => db-inserter.openfaas-fn (15) bytes
+2019/12/13 17:07:16 tester got result: [200] drone-position/ => db-inserter.openfaas-fn (15) bytes
 ```
 
 ### 7) Add Grafana for function/service visualization

--- a/emitter/README.md
+++ b/emitter/README.md
@@ -1,3 +1,9 @@
+## Emitter.io
+
+[Emitter.io](https://emitter.io) is a MQTT broker with additional security provided via channel keys.
+
+## Get started
+
 First run Emitter in docker to generate a `EMITTER_LICENSE`. (Note that this is
 not a software license key.)
 
@@ -14,7 +20,19 @@ docker logs emitter
 2019/12/10 06:40:16 [license] generated new secret key: aV3hzU01-SCF0wbnDdpXKCyxT4OB5Gad
 ```
 
-Copy the new license into `broker.yaml` and start the broker and service.
+* Create a Kubernetes secret to store the key
+
+```sh
+kubectl create secret generic emitter-secret -n openfaas --from-literal "secret=aV3hzU01-SCF0wbnDdpXKCyxT4OB5Gad"
+```
+
+## Edit `broker.yaml`
+
+* Copy the new license into `broker.yaml` and start the broker and service.
+
+* Update `replicas: 3` with the number of nodes, use "1" for the default
+
+## Deploy
 
 For simplicity, the broker is deployed to the `openfaas` namespace.
 
@@ -22,6 +40,8 @@ For simplicity, the broker is deployed to the `openfaas` namespace.
 kubectl apply -f broker.yaml
 kubectl apply -f service.yaml
 ```
+
+## Check the deployment
 
 List the services to obtain the IP address of the Emitter load balancer.
 
@@ -40,12 +60,14 @@ kubectl logs statefulset.apps/broker -n openfaas
 Port-forward the Emitter's UI so that you can generate a channel key.
 
 ```sh
-kubectl port-forward -n openfaas svc emitter 8080:8080 &
+kubectl port-forward -n openfaas svc/emitter 8081:8080 &
 ```
 
 You can now use the IP address to access the Emitter UI. In the above example
-you would go to `http://127.0.0.1:8080/keygen`. From there you can create
+you would go to `http://127.0.0.1:8081/keygen`. From there you can create
 channel keys, which allow you to secure individual channels and start using
 Emitter.
+
+You will need to enter the secret from above i.e. `aV3hzU01-SCF0wbnDdpXKCyxT4OB5Gad` or similar. If you can't remember the password, then look it up from the Kubernetes secret, and decode it with `kubectl get  secret/emitter-secret -o yaml -n openfaas` followed by `base64 -D` against the `secret` field.
 
 You can now proceed with the [Emitter documentation](https://github.com/emitter-io/emitter).

--- a/emitter/broker.yaml
+++ b/emitter/broker.yaml
@@ -8,7 +8,7 @@ spec:
     matchLabels:
       app: broker # has to match .spec.template.metadata.labels
   serviceName: "broker"
-  replicas: 3
+  replicas: 3 # Alter to match number of nodes, use "1" for the defaults
   template:
     metadata:
       labels:
@@ -30,7 +30,7 @@ spec:
       containers:
       - env:
         - name: EMITTER_LICENSE
-          value: "RfBEIAngTSCjWuEMrmsFe3qgYTWJiM7N9iZJsRtq8sjrD8OdGJ3QitnOkmzQXMWxFQ1o2nqdn5731Pe4s4PF1rME37CBnwYB:2" # <- Provide license
+          value: "RfBEIFFk0ez8e8hJhBJaY9pq1lSUulKOl99FZzF1Cf_fKfPnGA1tY4lzQeUAYvf2_npUXTx4HDfA9g9pcPi4hqsEjLjQqgwB:2" # <- Provide license
         - name: EMITTER_CLUSTER_SEED
           value: "broker" # or "broker-0.broker.default.svc.cluster.local"
         - name: EMITTER_CLUSTER_ADVERTISE

--- a/openfaas/services/publisher.py
+++ b/openfaas/services/publisher.py
@@ -1,0 +1,20 @@
+import paho.mqtt.publish as publish
+import paho.mqtt.client as mqtt
+import os, json
+
+def on_publish(client,userdata,result):
+    print("data published \n")
+    pass
+
+client = mqtt.Client("127.0.0.1:8081", transport="websockets")
+
+client.on_publish = on_publish
+broker = "127.0.0.1"
+port = 8081
+
+client.connect(broker, port)
+
+payload = json.dumps({"name": "Carpark-watch", "tempCelsius": 3.5, "location": {"lat": 52.5740072, "lon": -0.2399354}, "batteryMv": 2700})
+
+ret = client.publish(os.getenv("CHANNEL_KEY"), payload)
+print(ret)

--- a/openfaas/services/render-map/README.md
+++ b/openfaas/services/render-map/README.md
@@ -20,6 +20,14 @@
 
     The `axios` module will be used to call back into `db-reader`, during development this uses the react proxy. As a production deployment (below), it uses the OpenFaaS gateway URL.
 
+### Mapbox reference
+
+    * Mapbox GL JS + React - https://docs.mapbox.com/help/tutorials/use-mapbox-gl-js-with-react/
+
+    * GeoJSON and other drawing - https://docs.mapbox.com/mapbox-gl-js/example/geojson-markers/
+
+    * Use Mapbox GL JS in a React app - https://blog.mapbox.com/mapbox-gl-js-react-764da6cc074a
+
 ## Deploying to production:
 
     ```sh


### PR DESCRIPTION
* Sample publisher in Python3 written and tested and to end
on Packet with the mqtt-connector
* Fixed emitter instructions so that the user keeps track of the
secret which is required for the "keygen" step for the channel
key

After running the publisher to emit a message to MQTT, the map updated as per below

Connector logs:

```
kubectl logs -n openfaas deployment.apps/openfaas-mqtt-connector -f
2019/12/13 17:05:43 Topic: i-Xrxb7mpm-bs5LVY3jDU_kcE2XAgnyY/drone-position/	Broker: tcp://emitter:8080
Send: "{\"name\": \"Carpark-watch\", \"tempCelsius\": 3.5, \"location\": {\"lat\": 52.5740072, \"lon\": -0.2399354}, \"batteryMv\": 2700}"
2019/12/13 17:07:16 Invoking (http://gateway.openfaas:8080) on topic: "drone-position/", value: "{\"name\": \"Carpark-watch\", \"tempCelsius\": 3.5, \"location\": {\"lat\": 52.5740072, \"lon\": -0.2399354}, \"batteryMv\": 2700}"
2019/12/13 17:07:16 Invoke function: db-inserter.openfaas-fn
[200] drone-position/ => db-inserter.openfaas-fn
{"status":"OK"}
2019/12/13 17:07:16 connector-sdk got result: [200] drone-position/ => db-inserter.openfaas-fn (15) bytes
2019/12/13 17:07:16 tester got result: [200] drone-position/ => db-inserter.openfaas-fn (15) bytes
```

Publisher code:

```
payload = json.dumps({"name": "Carpark-watch", "tempCelsius": 3.5, "location": {"lat": 52.5740072, "lon": -0.2399354}, "batteryMv": 2700})

ret = client.publish(os.getenv("CHANNEL_KEY"), payload)
```
![Screenshot 2019-12-13 at 17 08 19](https://user-images.githubusercontent.com/6358735/70818518-d5c14080-1dcb-11ea-86a2-71927d61fe91.png)
